### PR TITLE
bump dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ node_js:
   - "5.1"
   - "5.2"
   - "5.3"
+  - "5.4"
 sudo: false
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "intelli-espower-loader": "^1.0.1",
     "mocha": "^2.3.4",
     "power-assert": "^1.2.0",
-    "socket.io": "^1.4.0",
-    "socket.io-client": "^1.4.0",
+    "socket.io": "^1.4.4",
+    "socket.io-client": "^1.4.4",
     "standard": "^5.4.1"
   }
 }


### PR DESCRIPTION
- socket.io 1.4.4
- socket.io-client 1.4.4
- node.js v5.4