### PR TITLE
Ensure args is an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,11 @@ module.exports = function (CustomEmitter) {
   var emit = Emitter.prototype.emit
 
   function onevent (packet) {
-    var args = packet.data || []
+    var args = [];
+
+    if (packet.data && packet.data.constructor === Array) {
+      args = packet.data
+    }
     if (packet.id != null) {
       args.push(this.ack(packet.id))
     }


### PR DESCRIPTION
Id packet.id is null and packet.data is not an array you can expect this error:

CreateListFromArrayLike called on non-object

This commit is fixing this.