### PR TITLE
Added docs for using this middleware with a namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ io.on('connection', function(socket) {
 io.listen(8000);
 ```
 
+### Server (with a namespace)
+
+```diff
+var io         = require('socket.io')();
++var nsp        = io.of('/namespace');
+var middleware = require('socketio-wildcard')();
+
+-io.use(middleware);
++nsp.use(middleware);
+
+-io.on('connection', function(socket) {
++nsp.on('connection', function(socket) {
+  socket.on('*', function(packet){
+    // client.emit('foo', 'bar', 'baz')
+    packet.data === ['foo', 'bar', 'baz']
+  });
+});
+
+io.listen(8000);
+```
+
 ### Client
 
 ```js


### PR DESCRIPTION
This might have been obvious or I missed it, but middleware should be installed for each namespace separately. In other words, if you install the wildcard middleware for the root namespace (`io.use`), sockets connected to other namespaces won't fire their `*` event. Took me a while to figure it out.